### PR TITLE
Update to OpenTracing 0.12.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.0" PrivateAssets="All" />
-    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.0" />
+    <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.1" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.1" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.1" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTracing.Contrib.Grpc/Extensions.cs
+++ b/src/OpenTracing.Contrib.Grpc/Extensions.cs
@@ -20,46 +20,6 @@ namespace OpenTracing.Contrib.Grpc
                 });
         }
 
-        public static ISpanBuilder WithTag(this ISpanBuilder spanBuilder, AbstractTag<bool> tagSetter, bool value)
-        {
-            return spanBuilder.WithTag(tagSetter.Key, value);
-        }
-
-        public static ISpanBuilder WithTag(this ISpanBuilder spanBuilder, AbstractTag<int> tagSetter, int value)
-        {
-            return spanBuilder.WithTag(tagSetter.Key, value);
-        }
-
-        public static ISpanBuilder WithTag(this ISpanBuilder spanBuilder, AbstractTag<double> tagSetter, double value)
-        {
-            return spanBuilder.WithTag(tagSetter.Key, value);
-        }
-
-        public static ISpanBuilder WithTag(this ISpanBuilder spanBuilder, AbstractTag<string> tagSetter, string value)
-        {
-            return spanBuilder.WithTag(tagSetter.Key, value);
-        }
-
-        public static ISpan SetTag(this ISpan span, AbstractTag<string> tagSetter, string value)
-        {
-            return span.SetTag(tagSetter.Key, value);
-        }
-
-        public static ISpan SetTag(this ISpan span, AbstractTag<bool> tagSetter, bool value)
-        {
-            return span.SetTag(tagSetter.Key, value);
-        }
-
-        public static ISpan SetTag(this ISpan span, AbstractTag<int> tagSetter, int value)
-        {
-            return span.SetTag(tagSetter.Key, value);
-        }
-
-        public static ISpan SetTag(this ISpan span, AbstractTag<double> tagSetter, double value)
-        {
-            return span.SetTag(tagSetter.Key, value);
-        }
-
         public static TimeSpan TimeRemaining(this DateTime deadline)
         {
             return deadline.Subtract(DateTime.UtcNow);

--- a/src/OpenTracing.Contrib.Grpc/GrpcTraceLogger.cs
+++ b/src/OpenTracing.Contrib.Grpc/GrpcTraceLogger.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Grpc.Core;
 using OpenTracing.Contrib.Grpc.Configuration;
-using OpenTracing.Tag;
 
 namespace OpenTracing.Contrib.Grpc
 {

--- a/src/OpenTracing.Contrib.Grpc/Handler/InterceptedClientHandler.cs
+++ b/src/OpenTracing.Contrib.Grpc/Handler/InterceptedClientHandler.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 using OpenTracing.Contrib.Grpc.Configuration;
-using OpenTracing.Contrib.Grpc.Interceptors;
 using OpenTracing.Contrib.Grpc.Propagation;
 using OpenTracing.Contrib.Grpc.Streaming;
 using OpenTracing.Propagation;

--- a/src/OpenTracing.Contrib.Grpc/OpenTracing.Contrib.Grpc.csproj
+++ b/src/OpenTracing.Contrib.Grpc/OpenTracing.Contrib.Grpc.csproj
@@ -13,8 +13,4 @@
     <PackageReference Include="OpenTracing" Version="0.12.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="SourceLink.Create.GitHub" Version="2.8.1" />
-  </ItemGroup>
-
 </Project>

--- a/src/OpenTracing.Contrib.Grpc/OpenTracing.Contrib.Grpc.csproj
+++ b/src/OpenTracing.Contrib.Grpc/OpenTracing.Contrib.Grpc.csproj
@@ -9,8 +9,12 @@
 
   <ItemGroup>
     <!-- Main dependencies -->
-    <PackageReference Include="Grpc" Version="1.11.0" />
-    <PackageReference Include="OpenTracing" Version="0.11.0" />
+    <PackageReference Include="Grpc" Version="1.12.0" />
+    <PackageReference Include="OpenTracing" Version="0.12.0-rc1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="SourceLink.Create.GitHub" Version="2.8.1" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTracing.Contrib.Grpc/OpenTracing.Contrib.Grpc.csproj
+++ b/src/OpenTracing.Contrib.Grpc/OpenTracing.Contrib.Grpc.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <!-- Main dependencies -->
     <PackageReference Include="Grpc" Version="1.12.0" />
-    <PackageReference Include="OpenTracing" Version="0.12.0-rc1" />
+    <PackageReference Include="OpenTracing" Version="0.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTracing.Contrib.Grpc.Test/OpenTracing.Contrib.Grpc.Test.csproj
+++ b/test/OpenTracing.Contrib.Grpc.Test/OpenTracing.Contrib.Grpc.Test.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.5.1" />
-    <PackageReference Include="Grpc" Version="1.11.0" />
+    <PackageReference Include="Grpc" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This currently targets OpenTracing v0.12.0-rc1. I'll update this PR as soon as the final version is released.