### PR TITLE
Don't use AppVeyor nuget feed (or any other)

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
The AppVeyor-build [currently throws a 401 warning](https://ci.appveyor.com/project/opentracing/csharp-grpc/build/14) because it tries to resolve packages from the AppVeyor NuGet feed. Packages are published to this feed via the "nuget:" settings in .appveyor.yml but we don't need to resolve packages from there automatically. 

This nuget.config file ensures that packages are always taken from the official nuget feed.