### PR TITLE
Add CallCredentials and CallOptions serialization.

### DIFF
--- a/src/OpenTracing.Contrib.Grpc/Extensions.cs
+++ b/src/OpenTracing.Contrib.Grpc/Extensions.cs
@@ -35,5 +35,23 @@ namespace OpenTracing.Contrib.Grpc
 
             return string.Join(";", metadata.Select(e => $"{e.Key} = {e.Value}"));
         }
+
+        public static string ToReadableString(this CallOptions options)
+        {
+            // Should this be converted to milis?
+            var deadline = options.Deadline.HasValue ? options.Deadline.Value.ToUniversalTime().ToString() : "Infinite";
+            var headers = options.Headers.ToReadableString() ?? "Empty";
+            var writeOptions = options.WriteOptions == null ? "None" : options.WriteOptions.Flags.ToString();
+            var isContextPropagated = options.PropagationToken != null;
+
+            return $"Headers: {headers}; Deadline: {deadline}; IsWaitForReady: {options.IsWaitForReady}; WriteOptions: {writeOptions} IsContextPropagated: {isContextPropagated}";
+        }
+
+        public static string GetAuthorizationHeaderValue(this Metadata headers)
+        {
+            var authorization = headers?.FirstOrDefault(x => x.Key.Equals("authorization", StringComparison.OrdinalIgnoreCase))?.Value;
+
+            return string.IsNullOrWhiteSpace(authorization) ? "NoAuth" : authorization;
+        }
     }
 }

--- a/src/OpenTracing.Contrib.Grpc/Extensions.cs
+++ b/src/OpenTracing.Contrib.Grpc/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Grpc.Core;
 using OpenTracing.Tag;
@@ -39,12 +40,16 @@ namespace OpenTracing.Contrib.Grpc
         public static string ToReadableString(this CallOptions options)
         {
             // Should this be converted to milis?
-            var deadline = options.Deadline.HasValue ? options.Deadline.Value.ToUniversalTime().ToString() : "Infinite";
+            var deadline = options.Deadline.HasValue ? options.Deadline.Value.ToUniversalTime().ToString(CultureInfo.InvariantCulture) : "Infinite";
             var headers = options.Headers.ToReadableString() ?? "Empty";
-            var writeOptions = options.WriteOptions == null ? "None" : options.WriteOptions.Flags.ToString();
+            var writeOptions = options.WriteOptions != null ? options.WriteOptions.Flags.ToString() : "None";
             var isContextPropagated = options.PropagationToken != null;
 
-            return $"Headers: {headers}; Deadline: {deadline}; IsWaitForReady: {options.IsWaitForReady}; WriteOptions: {writeOptions} IsContextPropagated: {isContextPropagated}";
+            return $"Headers: {headers}; " +
+                   $"Deadline: {deadline}; " +
+                   $"IsWaitForReady: {options.IsWaitForReady}; " +
+                   $"WriteOptions: {writeOptions} " +
+                   $"IsContextPropagated: {isContextPropagated}";
         }
 
         public static string GetAuthorizationHeaderValue(this Metadata headers)

--- a/src/OpenTracing.Contrib.Grpc/Handler/InterceptedClientHandler.cs
+++ b/src/OpenTracing.Contrib.Grpc/Handler/InterceptedClientHandler.cs
@@ -11,8 +11,8 @@ using OpenTracing.Tag;
 
 namespace OpenTracing.Contrib.Grpc.Handler
 {
-    internal class InterceptedClientHandler<TRequest, TResponse> 
-        where TRequest : class 
+    internal class InterceptedClientHandler<TRequest, TResponse>
+        where TRequest : class
         where TResponse : class
     {
         private readonly ClientTracingConfiguration _configuration;
@@ -23,9 +23,9 @@ namespace OpenTracing.Contrib.Grpc.Handler
         {
             _configuration = configuration;
             _context = context;
-            if (context.Options.Headers == null)
+            if(context.Options.Headers == null)
             {
-                _context = new ClientInterceptorContext<TRequest, TResponse>(context.Method, context.Host, 
+                _context = new ClientInterceptorContext<TRequest, TResponse>(context.Method, context.Host,
                     context.Options.WithHeaders(new Metadata())); // Add empty metadata to options
             }
 
@@ -42,9 +42,9 @@ namespace OpenTracing.Contrib.Grpc.Handler
                 .WithTag(Tags.Component, Constants.TAGS_COMPONENT)
                 .WithTag(Tags.SpanKind, Tags.SpanKindClient);
 
-            foreach (var attribute in _configuration.TracedAttributes)
+            foreach(var attribute in _configuration.TracedAttributes)
             {
-                switch (attribute)
+                switch(attribute)
                 {
                     case ClientTracingConfiguration.RequestAttribute.MethodType:
                         spanBuilder.WithTag(Constants.TAGS_GRPC_METHOD_TYPE, _context.Method?.Type.ToString());
@@ -57,11 +57,11 @@ namespace OpenTracing.Contrib.Grpc.Handler
                         break;
                     case ClientTracingConfiguration.RequestAttribute.Authority:
                         // TODO: Serialization is wrong
-                        spanBuilder.WithTag(Constants.TAGS_GRPC_AUTHORITY, _context.Options.Credentials?.ToString());
+                        spanBuilder.WithTag(Constants.TAGS_GRPC_AUTHORITY, _context.Options.Headers.GetAuthorizationHeaderValue());
                         break;
                     case ClientTracingConfiguration.RequestAttribute.AllCallOptions:
                         // TODO: Serialization is wrong
-                        spanBuilder.WithTag(Constants.TAGS_GRPC_CALL_OPTIONS, _context.Options.ToString());
+                        spanBuilder.WithTag(Constants.TAGS_GRPC_CALL_OPTIONS, _context.Options.ToReadableString());
                         break;
                     case ClientTracingConfiguration.RequestAttribute.Headers:
                         // TODO: Check if this is always present immediately, expecially in case of streaming!
@@ -89,7 +89,7 @@ namespace OpenTracing.Contrib.Grpc.Handler
                 _logger.FinishSuccess();
                 return response;
             }
-            catch (Exception ex)
+            catch(Exception ex)
             {
                 _logger.FinishException(ex);
                 throw;
@@ -109,7 +109,7 @@ namespace OpenTracing.Contrib.Grpc.Handler
                     _logger.FinishSuccess();
                     return response;
                 }
-                catch (AggregateException ex)
+                catch(AggregateException ex)
                 {
                     _logger.FinishException(ex.InnerException);
                     throw ex.InnerException;
@@ -141,7 +141,7 @@ namespace OpenTracing.Contrib.Grpc.Handler
                     _logger.FinishSuccess();
                     return response;
                 }
-                catch (AggregateException ex)
+                catch(AggregateException ex)
                 {
                     _logger.FinishException(ex.InnerException);
                     throw ex.InnerException;

--- a/src/OpenTracing.Contrib.Grpc/Handler/InterceptedClientHandler.cs
+++ b/src/OpenTracing.Contrib.Grpc/Handler/InterceptedClientHandler.cs
@@ -23,7 +23,7 @@ namespace OpenTracing.Contrib.Grpc.Handler
         {
             _configuration = configuration;
             _context = context;
-            if(context.Options.Headers == null)
+            if (context.Options.Headers == null)
             {
                 _context = new ClientInterceptorContext<TRequest, TResponse>(context.Method, context.Host,
                     context.Options.WithHeaders(new Metadata())); // Add empty metadata to options
@@ -42,9 +42,9 @@ namespace OpenTracing.Contrib.Grpc.Handler
                 .WithTag(Tags.Component, Constants.TAGS_COMPONENT)
                 .WithTag(Tags.SpanKind, Tags.SpanKindClient);
 
-            foreach(var attribute in _configuration.TracedAttributes)
+            foreach (var attribute in _configuration.TracedAttributes)
             {
-                switch(attribute)
+                switch (attribute)
                 {
                     case ClientTracingConfiguration.RequestAttribute.MethodType:
                         spanBuilder.WithTag(Constants.TAGS_GRPC_METHOD_TYPE, _context.Method?.Type.ToString());
@@ -56,11 +56,9 @@ namespace OpenTracing.Contrib.Grpc.Handler
                         spanBuilder.WithTag(Constants.TAGS_GRPC_DEADLINE_MILLIS, _context.Options.Deadline?.TimeRemaining().TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
                         break;
                     case ClientTracingConfiguration.RequestAttribute.Authority:
-                        // TODO: Serialization is wrong
                         spanBuilder.WithTag(Constants.TAGS_GRPC_AUTHORITY, _context.Options.Headers.GetAuthorizationHeaderValue());
                         break;
                     case ClientTracingConfiguration.RequestAttribute.AllCallOptions:
-                        // TODO: Serialization is wrong
                         spanBuilder.WithTag(Constants.TAGS_GRPC_CALL_OPTIONS, _context.Options.ToReadableString());
                         break;
                     case ClientTracingConfiguration.RequestAttribute.Headers:
@@ -89,7 +87,7 @@ namespace OpenTracing.Contrib.Grpc.Handler
                 _logger.FinishSuccess();
                 return response;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 _logger.FinishException(ex);
                 throw;
@@ -109,7 +107,7 @@ namespace OpenTracing.Contrib.Grpc.Handler
                     _logger.FinishSuccess();
                     return response;
                 }
-                catch(AggregateException ex)
+                catch (AggregateException ex)
                 {
                     _logger.FinishException(ex.InnerException);
                     throw ex.InnerException;
@@ -141,7 +139,7 @@ namespace OpenTracing.Contrib.Grpc.Handler
                     _logger.FinishSuccess();
                     return response;
                 }
-                catch(AggregateException ex)
+                catch (AggregateException ex)
                 {
                     _logger.FinishException(ex.InnerException);
                     throw ex.InnerException;

--- a/src/OpenTracing.Contrib.Grpc/Handler/InterceptedServerHandler.cs
+++ b/src/OpenTracing.Contrib.Grpc/Handler/InterceptedServerHandler.cs
@@ -41,7 +41,7 @@ namespace OpenTracing.Contrib.Grpc.Handler
                         spanBuilder.WithTag(Constants.TAGS_GRPC_METHOD_NAME, _context.Method);
                         break;
                     case ServerTracingConfiguration.RequestAttribute.Headers:
-                        // TODO: Check if this is always present immediately, expecially in case of streaming!
+                        // TODO: Check if this is always present immediately, especially in case of streaming!
                         spanBuilder.WithTag(Constants.TAGS_GRPC_HEADERS, _context.RequestHeaders?.ToReadableString());
                         break;
                 }

--- a/src/OpenTracing.Contrib.Grpc/Interceptors/ClientTracingInterceptor.cs
+++ b/src/OpenTracing.Contrib.Grpc/Interceptors/ClientTracingInterceptor.cs
@@ -95,7 +95,7 @@ namespace OpenTracing.Contrib.Grpc.Interceptors
                 return this;
             }
 
-            /// <param name="tracedAttributes">to set as tags on client spans created by this intercepter</param>
+            /// <param name="tracedAttributes">to set as tags on client spans created by this interceptor</param>
             /// <returns>this Builder configured to trace attributes</returns>
             public Builder WithTracedAttributes(params ClientTracingConfiguration.RequestAttribute[] tracedAttributes)
             {

--- a/src/OpenTracing.Contrib.Grpc/OpenTracing.Contrib.Grpc.csproj
+++ b/src/OpenTracing.Contrib.Grpc/OpenTracing.Contrib.Grpc.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard1.5</TargetFramework>

--- a/test/OpenTracing.Contrib.Grpc.Test/OpenTracing.Contrib.Grpc.Test.csproj
+++ b/test/OpenTracing.Contrib.Grpc.Test/OpenTracing.Contrib.Grpc.Test.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>OpenTracing.Contrib.Grpc.Test</RootNamespace>
     <AssemblyName>OpenTracing.Contrib.Grpc.Test</AssemblyName>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenTracing.Contrib.Grpc.Test/Program.cs
+++ b/test/OpenTracing.Contrib.Grpc.Test/Program.cs
@@ -88,11 +88,12 @@ namespace OpenTracing.Contrib.Grpc.Test
                         .WithWriteOptions(new WriteOptions(WriteFlags.NoCompress));
 
                 var response5 = await client.GetNameAsync(
-                    new Person() { Name = "Test" },
+                    new Person { Name = "Test" },
                     options);
             }
             catch
             {
+                // Ignore
             }
 
             await server.ShutdownAsync();

--- a/test/OpenTracing.Contrib.Grpc.Test/Program.cs
+++ b/test/OpenTracing.Contrib.Grpc.Test/Program.cs
@@ -1,16 +1,17 @@
-﻿using Grpc.Core;
-using Grpc.Core.Interceptors;
-using OpenTracing.Mock;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using OpenTracing.Contrib.Grpc.Configuration;
 using OpenTracing.Contrib.Grpc.Interceptors;
+using OpenTracing.Mock;
 using Tutorial;
 
 namespace OpenTracing.Contrib.Grpc.Test
 {
-    class Program
+    internal class Program
     {
         private class ConsoleMockTracer : MockTracer
         {
@@ -20,8 +21,8 @@ namespace OpenTracing.Contrib.Grpc.Test
                 Console.WriteLine("Tags:");
                 Console.WriteLine(string.Join("; ", span.Tags.Select(e => $"{e.Key} = {e.Value}")));
                 Console.WriteLine("Logs:");
-                span.LogEntries.ForEach(entry => 
-                    Console.WriteLine($"Timestamp: {entry.Timestamp}, Fields: " 
+                span.LogEntries.ForEach(entry =>
+                    Console.WriteLine($"Timestamp: {entry.Timestamp}, Fields: "
                                       + string.Join("; ", entry.Fields.Select(e => $"{e.Key} = {e.Value}"))));
                 Console.WriteLine();
             }
@@ -29,9 +30,9 @@ namespace OpenTracing.Contrib.Grpc.Test
 
         private static readonly ServerTracingInterceptor ServerTracingInterceptor = new ServerTracingInterceptor(new ConsoleMockTracer());
 
-        static void Main()
+        private static Task Main()
         {
-            MainAsync().Wait();
+            return MainAsync();
         }
 
         private static async Task MainAsync()
@@ -42,7 +43,15 @@ namespace OpenTracing.Contrib.Grpc.Test
                 Services = { Phone.BindService(new PhoneImpl()).Intercept(ServerTracingInterceptor) }
             };
             server.Start();
-            var client = new Phone.PhoneClient(new Channel("localhost:8011", ChannelCredentials.Insecure).Intercept(ServerTracingInterceptor));
+
+            var tracingInterceptor = new ClientTracingInterceptor
+                .Builder(new ConsoleMockTracer())
+                .WithStreaming()
+                .WithVerbosity()
+                .WithTracedAttributes(ClientTracingConfiguration.RequestAttribute.AllCallOptions, ClientTracingConfiguration.RequestAttribute.Headers)
+                .Build();
+
+            var client = new Phone.PhoneClient(new Channel("localhost:8011", ChannelCredentials.Insecure).Intercept(tracingInterceptor));
             var request = new Person { Name = "Karl Heinz" };
             var response1 = await client.GetNameAsync(request);
 
@@ -71,7 +80,16 @@ namespace OpenTracing.Contrib.Grpc.Test
 
             try
             {
-                var response5 = await client.GetNameAsync(new Person());
+                var options =
+                    new CallOptions()
+                        .WithHeaders(new Metadata { { "CorrelationId", Guid.NewGuid().ToString() } })
+                        .WithDeadline(DateTime.UtcNow.AddHours(1))
+                        .WithWaitForReady(true)
+                        .WithWriteOptions(new WriteOptions(WriteFlags.NoCompress));
+
+                var response5 = await client.GetNameAsync(
+                    new Person() { Name = "Test" },
+                    options);
             }
             catch
             {
@@ -80,7 +98,7 @@ namespace OpenTracing.Contrib.Grpc.Test
             await server.ShutdownAsync();
             Console.ReadLine();
         }
-        
+
         public class PhoneImpl : Phone.PhoneBase
         {
             public override Task<Person> GetName(Person request, ServerCallContext context)


### PR DESCRIPTION
Fixes #3 

* CallCredentials serialization:
  As far as I managed to see there is [GoogleGrpcCredentials](https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.Auth/GoogleGrpcCredentials.cs) implementation for this one and it only adds an "Authorization" header to Metadata object, so I decided to check only for that header.

* CallOptions serialization:
  - Deadline: maybe the date format I chose is not very smart, perhaps converting it to milliseconds or nanos makes it easier to use?
  - ContextPropagationToken: This one only has [internal implementation](https://github.com/grpc/grpc/blob/f0bfcd864c7a2395ad82ff9db8e39d0c51d49ee0/src/csharp/Grpc.Core/Internal/ContextPropagationTokenImpl.cs), so I decided only to add flag "IsContextPropagated", but it might feel misleading since there isn't a property like that one.

I extended the existing test app, but haven't created any unit tests since I couldn't find any at the moment. Maybe we can add some in a separate PR?