### PR TITLE
Update GitHub auth token

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,6 +33,6 @@ deploy:
     description: "See milestone for changes: https://github.com/opentracing-contrib/csharp-grpc/milestones"
     draft: true
     auth_token:
-      secure: VD2KNkqKnAIEm3QWxqCLC3KaVrQjfxsaV9NiuLCvrTEAk4p5ZmI462RA4qoB21KS
+      secure: 4zbtMttqfBfv1zsFBS6mUY+KHaACsFcvc+zVH0Y2BTI2w3ImAQhk7c4Fdet5OGG+
     on:
       appveyor_repo_tag: true


### PR DESCRIPTION
@Falco20019 Seems like the error in #16 came from not being able to create the GitHub release:
![image](https://user-images.githubusercontent.com/4581460/72466206-b5284400-37d8-11ea-8267-0b8110862819.png)

I've therefore created a new personal GitHub access token with the "repo_public" permission, encrypted the value in AppVeyor and put it in here. (as described in https://www.appveyor.com/docs/deployment/github/)

I wasn't really able to test this though, so just let me know if it doesn't work.