### PR TITLE
Add support for read-only metadata

### DIFF
--- a/src/OpenTracing.Contrib.Grpc/GrpcTraceLogger.cs
+++ b/src/OpenTracing.Contrib.Grpc/GrpcTraceLogger.cs
@@ -35,7 +35,7 @@ namespace OpenTracing.Contrib.Grpc
             _span.Log(new Dictionary<string, object>
             {
                 { LogFields.Event, "Response headers received" },
-                { "data", metadata }
+                { "data", metadata?.ToReadableString() }
             });
         }
 


### PR DESCRIPTION
As of now, if read-only metadata is given, the client interceptor would fail trying to inject the headers. In case that they are read-only, we need to make a defensive copy.